### PR TITLE
Hide the searchbar placeholder text when it contains text

### DIFF
--- a/_assets/js/search.js.liquid
+++ b/_assets/js/search.js.liquid
@@ -7,19 +7,6 @@
 //= require 'vendor/jquery.lunr.search'
 
 $(document).ready(function(){
-    $('.search-input').focus(function() {
-        $.getJSON( "{{site.baseurl}}/search-engine/index.json");
-    });
-
-    // If search-input has value add class that moves it in front of label
-    $('#site-search-text').on("propertychange input", function () { // input = ie9+, propertychange < ie9
-        element = $(this);
-        if (element.val()) {
-            element.addClass('has-value');
-        } else {
-            element.removeClass('has-value');
-        }
-    });
     $(function() {
         $('#search-query').lunrSearch({
             indexUrl: '{{site.baseurl}}/search-engine/index.json',   // Url for the .json file containing search index data

--- a/_assets/js/searchbar.js
+++ b/_assets/js/searchbar.js
@@ -1,0 +1,26 @@
+
+window.addEventListener('load', function () {
+    var siteSearchText = document.getElementById("site-search-text");
+
+    function onSiteSearchChange() {
+        // If search-input is not empty, add class that moves it in front of label
+        if (siteSearchText.value) {
+            //Add the class if it doesnt have it already
+            var className = siteSearchText.className;
+            if(!className.contains("has-value")) {
+                if (className!= "") {
+                    className += " ";
+                }
+                className += "has-value";
+                siteSearchText.className = className;
+            }
+        }
+        else {
+            //Remove the class
+            siteSearchText.className = siteSearchText.className.replace("has-value","");
+        }
+    }
+
+    siteSearchText.addEventListener("change", onSiteSearchChange, false);
+    onSiteSearchChange();
+});

--- a/_assets/js/searchbar.js.liquid
+++ b/_assets/js/searchbar.js.liquid
@@ -7,7 +7,7 @@ window.addEventListener('load', function () {
         if (siteSearchText.value) {
             //Add the class if it doesnt have it already
             var className = siteSearchText.className;
-            if(!className.contains("has-value")) {
+            if (className.toString().indexOf("has-value") < 0) {
                 if (className!= "") {
                     className += " ";
                 }

--- a/_assets/js/searchbar.js.liquid
+++ b/_assets/js/searchbar.js.liquid
@@ -21,6 +21,20 @@ window.addEventListener('load', function () {
         }
     }
 
+    // when the searchbar gets focus, fetch the search index so it is cached for later
+    function onSiteSearchFocus() {
+        var http;
+        if (window.XMLHttpRequest) {
+          http = new XMLHttpRequest();
+        }
+        else {
+          http = new XDomainRequest();
+        }
+        http.open("GET", "{{site.baseurl}}/search-engine/index.json", true);
+        http.send();
+    }
+
+    siteSearchText.addEventListener("focus", onSiteSearchFocus, false);
     siteSearchText.addEventListener("change", onSiteSearchChange, false);
     onSiteSearchChange();
 });

--- a/_assets/js/vendor/eventListenerIEPolyfill.js
+++ b/_assets/js/vendor/eventListenerIEPolyfill.js
@@ -1,0 +1,130 @@
+/**
+ * @license addEventListener polyfill 1.0 / Eirik Backer / MIT Licence
+ * https://gist.github.com/2864711/946225eb3822c203e8d6218095d888aac5e1748e
+ *
+ * sounisi5011 version:
+ * http://qiita.com/sounisi5011/items/a8fc80e075e4f767b79a#11
+ */
+(function (window, document, listeners_prop_name) {
+    if ((!window.addEventListener || !window.removeEventListener) && window.attachEvent && window.detachEvent) {
+        /**
+         * @param {*} value
+         * @return {boolean}
+         */
+        var is_callable = function (value) {
+            return typeof value === 'function';
+        };
+        /**
+         * @param {!Window|HTMLDocument|Node} self
+         * @param {EventListener|function(!Event):(boolean|undefined)} listener
+         * @return {!function(Event)|undefined}
+         */
+        var listener_get = function (self, listener) {
+            var listeners = listener[listeners_prop_name];
+            if (listeners) {
+                var lis;
+                var i = listeners.length;
+                while (i--) {
+                    lis = listeners[i];
+                    if (lis[0] === self) {
+                        return lis[1];
+                    }
+                }
+            }
+        };
+        /**
+         * @param {!Window|HTMLDocument|Node} self
+         * @param {EventListener|function(!Event):(boolean|undefined)} listener
+         * @param {!function(Event)} callback
+         * @return {!function(Event)}
+         */
+        var listener_set = function (self, listener, callback) {
+            var listeners = listener[listeners_prop_name] || (listener[listeners_prop_name] = []);
+            return listener_get(self, listener) || (listeners[listeners.length] = [self, callback], callback);
+        };
+        /**
+         * @param {string} methodName
+         */
+        var docHijack = function (methodName) {
+            var old = document[methodName];
+            document[methodName] = function (v) {
+                return addListen(old(v));
+            };
+        };
+        /**
+         * @this {!Window|HTMLDocument|Node}
+         * @param {string} type
+         * @param {EventListener|function(!Event):(boolean|undefined)} listener
+         * @param {boolean=} useCapture
+         */
+        var addEvent = function (type, listener, useCapture) {
+            if (is_callable(listener)) {
+                var self = this;
+                self.attachEvent(
+                    'on' + type,
+                    listener_set(self, listener, function (e) {
+                        e = e || window.event;
+                        e.preventDefault = e.preventDefault || function () { e.returnValue = false };
+                        e.stopPropagation = e.stopPropagation || function () { e.cancelBubble = true };
+                        e.target = e.target || e.srcElement || document.documentElement;
+                        e.currentTarget = e.currentTarget || self;
+                        e.timeStamp = e.timeStamp || (new Date()).getTime();
+                        listener.call(self, e);
+                    })
+                );
+            }
+        };
+        /**
+         * @this {!Window|HTMLDocument|Node}
+         * @param {string} type
+         * @param {EventListener|function(!Event):(boolean|undefined)} listener
+         * @param {boolean=} useCapture
+         */
+        var removeEvent = function (type, listener, useCapture) {
+            if (is_callable(listener)) {
+                var self = this;
+                var lis = listener_get(self, listener);
+                if (lis) {
+                    self.detachEvent('on' + type, lis);
+                }
+            }
+        };
+        /**
+         * @param {!Node|NodeList|Array} obj
+         * @return {!Node|NodeList|Array}
+         */
+        var addListen = function (obj) {
+            var i = obj.length;
+            if (i) {
+                while (i--) {
+                    obj[i].addEventListener = addEvent;
+                    obj[i].removeEventListener = removeEvent;
+                }
+            } else {
+                obj.addEventListener = addEvent;
+                obj.removeEventListener = removeEvent;
+            }
+            return obj;
+        };
+
+        addListen([document, window]);
+        if ('Element' in window) {
+            /**
+             * IE8
+             */
+            var element = window.Element;
+            element.prototype.addEventListener = addEvent;
+            element.prototype.removeEventListener = removeEvent;
+        } else {
+            /**
+             * IE < 8
+             */
+            //Make sure we also init at domReady
+            document.attachEvent('onreadystatechange', function () { addListen(document.all) });
+            docHijack('getElementsByTagName');
+            docHijack('getElementById');
+            docHijack('createElement');
+            addListen(document.all);
+        }
+    }
+})(window, document, 'x-ms-event-listeners');

--- a/_assets/scss/guide.scss
+++ b/_assets/scss/guide.scss
@@ -299,6 +299,11 @@ $site-search-outline--focus:                  $light-aqua;
   text-indent: 1em;
 }
 
+.lt-ie9 .site-search label {
+  // placeholder not supported, so show the text above the searchbar input
+  position: relative;
+}
+
 //Search results page
 .search-results {
   h3 {

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -19,7 +19,7 @@
 
   {% css syntax.light %}
 
-  {% include polyfill_scripts.liquid %}
+  {% include uikit_scripts.liquid %}
   {% js ui-kit.min %}
   {% js clipboard.min %}
 

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -19,7 +19,7 @@
 
   {% css syntax.light %}
 
-  {% include uikit_scripts.liquid %}
+  {% include polyfill_scripts.liquid %}
   {% js ui-kit.min %}
   {% js clipboard.min %}
 
@@ -27,6 +27,8 @@
   <script>svg4everybody();</script>
 
   {% js modernizr-svg-setclasses.min %}
+
+  {% js searchbar %}
 
   {% include google_fonts.liquid %}
   {% include google_analytics.liquid %}

--- a/_includes/polyfill_scripts.liquid
+++ b/_includes/polyfill_scripts.liquid
@@ -1,7 +1,17 @@
 <!--[if lt IE 9]>
+  <!-- scripts for UIKit -->
   <script type="text/javascript" src="//code.jquery.com/jquery-1.12.4.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/selectivizr/1.0.2/selectivizr-min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
-<![endif]-->
 
+  {% js eventListenerIEPolyfill %}
+<![endif]-->
+<script>
+  //Polyfill String.contains
+  if ( !String.prototype.contains ) {
+      String.prototype.contains = function() {
+          return String.prototype.indexOf.apply( this, arguments ) !== -1;
+      };
+  }
+</script>

--- a/_includes/uikit_scripts.liquid
+++ b/_includes/uikit_scripts.liquid
@@ -1,17 +1,6 @@
 <!--[if lt IE 9]>
-  <!-- scripts for UIKit -->
   <script type="text/javascript" src="//code.jquery.com/jquery-1.12.4.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/selectivizr/1.0.2/selectivizr-min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
-
-  {% js eventListenerIEPolyfill %}
 <![endif]-->
-<script>
-  //Polyfill String.contains
-  if ( !String.prototype.contains ) {
-      String.prototype.contains = function() {
-          return String.prototype.indexOf.apply( this, arguments ) !== -1;
-      };
-  }
-</script>

--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}"  class="no-js">
+<!--[if lte IE 7]>     <html lang="{{ page.lang | default: site.lang | default: "en" }}" class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="{{ page.lang | default: site.lang | default: "en" }}" class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="{{ page.lang | default: site.lang | default: "en" }}" class="no-js"> <!--<![endif]-->
 
   {% include head.liquid %}
 


### PR DESCRIPTION
Currently the search bar placeholder label has a bug where it is always overlaid on top of any text that is in the search bar:

![image](https://cloud.githubusercontent.com/assets/2324569/23533551/8f886a34-0006-11e7-90e8-bcfeb59e4ed7.png)

(We are using a label instead of the placeholder attribute for wider IE support)

This PR moves the search bar text in front of the placeholder if it is not empty.

The code that does this on dta.gov.au relied on jquery, so I've rewritten it for the content guide in vanilla js. Once this is working in the content guide I'll likely use it on dta.gov.au. 

I've tested it works in IE 8.


