### PR TITLE
Remove search result padding

### DIFF
--- a/_assets/scss/main.scss
+++ b/_assets/scss/main.scss
@@ -12,6 +12,5 @@ p.longdesc {
 }
 
 .list-search {
-  padding: 0 0 0 1em;
   margin: 0;
 }


### PR DESCRIPTION
Closes #110 
I just removed the padding entirely. Looks like this:
![image](https://cloud.githubusercontent.com/assets/2324569/25217788/95a9cbf0-25eb-11e7-8689-618eb613b883.png)
