### PR TITLE
Fix links that aren't prepending site.baseurl

### DIFF
--- a/_accessibility-inclusivity/audience-diversity.md
+++ b/_accessibility-inclusivity/audience-diversity.md
@@ -6,7 +6,7 @@ exclude_from_search: true
 
 Understand the diversity of your audience.
 
-Write [content that all users can read](/writing-style/#readability) and understand.
+Write [content that all users can read]({{ site.baseurl }}/writing-style/#readability) and understand.
 
 ### Australia is one of the most culturally diverse countries
 

--- a/_accessibility-inclusivity/images-alt-text.md
+++ b/_accessibility-inclusivity/images-alt-text.md
@@ -34,12 +34,15 @@ If the caption clearly explains the image make the alt text blank.
 
 In HTML5 [use the `<figcaption>` tag](https://www.w3.org/wiki/HTML/Elements/figcaption){:rel="external"} in the `<figure>` element.
 
+{% capture content %}
+<figure>
+  <img src='{{site.baseurl}}/assets/coat-of-arms.png' alt='' />
+  <figcaption>Caption: the conventional version of the Commonwealth Coat of Arms of Australia.</figcaption>
+</figure>
+{% endcapture %}
 {% include guide_example.liquid
   title = "image caption"
-  content= "<figure>
-  <img src='/assets/coat-of-arms.png' alt='' />
-  <figcaption>Caption: the conventional version of the Commonwealth Coat of Arms of Australia.</figcaption>
-</figure>"
+  content=content
 %}
 
 ### Informative images

--- a/_accessibility-inclusivity/links.md
+++ b/_accessibility-inclusivity/links.md
@@ -4,6 +4,6 @@ order: 6
 exclude_from_search: true
 ---
 
-Create [precise links and place them carefully](/content-structure/#hyperlinks) where users need them.
+Create [precise links and place them carefully]({{ site.baseurl }}/content-structure/#hyperlinks) where users need them.
 
 Make it easy for all users to know where they need to go.

--- a/_accessibility-inclusivity/screen-readers.md
+++ b/_accessibility-inclusivity/screen-readers.md
@@ -12,7 +12,7 @@ People use screen readers to navigate and understand web pages through a combina
 
 ### Clear writing helps all users
 
-Write clearly and use [plain English](/writing-style/#plain-english). This helps users with screen readers by making content easier to understand and to skim.
+Write clearly and use [plain English]({{ site.baseurl }}/writing-style/#plain-english). This helps users with screen readers by making content easier to understand and to skim.
 
 Keep sentences short so the meaning is concise. This means the screen reader won't need to read out a lot of punctuation. Not all screen readers work the same and some can miss nuances in longer sentences.
 
@@ -24,6 +24,6 @@ Screen readers can index web page headings, links and tags to create an overview
 
 Make web pages easier to navigate for screen readers using:
 
-- [hierarchical headings](/content-structure/#headings-and-subheadings)
-- [precise links](/content-structure/#hyperlinks) that can be understood on their own without the context of surrounding text
+- [hierarchical headings]({{ site.baseurl }}/content-structure/#headings-and-subheadings)
+- [precise links]({{ site.baseurl }}/content-structure/#hyperlinks) that can be understood on their own without the context of surrounding text
 - meaningful [image alt text and captions](#images-and-alt-text)

--- a/_accessibility-inclusivity/translation.md
+++ b/_accessibility-inclusivity/translation.md
@@ -32,4 +32,4 @@ Make sure the format of the translated content is accessible.
 
 If there is a user need for a PDF of the translated content you must:
 - make the plain English version available in HTML
-- [make the content in PDFs accessible](/accessibility-inclusivity/#pdf-accessibility)
+- [make the content in PDFs accessible]({{ site.baseurl }}/accessibility-inclusivity/#pdf-accessibility)

--- a/_content-structure/bullet-point-lists.md
+++ b/_content-structure/bullet-point-lists.md
@@ -14,7 +14,7 @@ Use a parallel structure for items so they all start in the same way. For exampl
 
 Aim to make each list item a similar size. This makes lists easier to scan.
 
-Don't add a [semicolon](/punctuation-grammar/#semicolons) to the end of list items.
+Don't add a [semicolon]({{ site.baseurl }}/punctuation-grammar/#semicolons) to the end of list items.
 
 ### Sentence fragment bullet point list
 

--- a/_content-structure/mobile-first.md
+++ b/_content-structure/mobile-first.md
@@ -12,7 +12,7 @@ It can be much harder for some people with disability to use a mobile device tha
 
 Think about how the content will work on a mobile device first. Then think about how it will translate to a larger screen.
 
-Write and design content that is consistent and uses [plain English](/writing-style/#plain-english) so [everyone can use it](/accessibility-inclusivity/).
+Write and design content that is consistent and uses [plain English]({{ site.baseurl }}/writing-style/#plain-english) so [everyone can use it]({{ site.baseurl }}/accessibility-inclusivity/).
 
 ### Communicate with text first
 

--- a/_formatting/italics.md
+++ b/_formatting/italics.md
@@ -12,7 +12,7 @@ Users with dyslexia can find italics very difficult to read.
 
 Don't use italics in headlines.
 
-Use [capitals instead of italics for acts and other publications](/punctuation-grammar/#capitalisation). Link to the source where possible.
+Use [capitals instead of italics for acts and other publications]({{ site.baseurl }}/punctuation-grammar/#capitalisation). Link to the source where possible.
 
 ### Avoid Latin words
 
@@ -25,7 +25,7 @@ a long time --- not _ad infinitum_
 "
 %}
 
-See guidance on [eg, ie, etc and nb](/punctuation-grammar/#eg-ie-etc-and-nb).
+See guidance on [eg, ie, etc and nb]({{ site.baseurl }}/punctuation-grammar/#eg-ie-etc-and-nb).
 
 An exception would be for scientific names.
 

--- a/_includes/collection_index.liquid
+++ b/_includes/collection_index.liquid
@@ -36,7 +36,7 @@ This is the main loop. It iterates through all collections.
         (unless it’s the index itself, which calls this very layout).
         {% endcomment %}
         {% for doc in collection_docs_ordered %}
-          <li><a href="{{ page.url }}#{{ doc.title | slugify }}">{{ doc.title }}</a></li>
+          <li><a href="#{{ doc.title | slugify }}">{{ doc.title }}</a></li>
         {% endfor %}
       </ul>
     </nav>
@@ -55,7 +55,7 @@ This is the main loop. It iterates through all collections.
 
   <article class="collection__item">
     <h2 id="{{ doc.title | slugify }}">
-      <a href="{{ page.url }}#{{ doc.title | slugify }}" class="headline-slug-link">
+      <a href="#{{ doc.title | slugify }}" class="headline-slug-link">
         {{ doc.title }}
       </a>
     </h2>

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -50,7 +50,7 @@
             Remove hardcoding.
           {% endcomment %}
           <ul>
-            <li><a href="/privacy/">Privacy statement</a></li>
+            <li><a href="{{ site.baseurl }}/privacy/">Privacy statement</a></li>
             <li><a href="https://groups.google.com/a/digital.gov.au/forum/#!forum/content-design-in-government" rel="external">Content Design in Government Google Group</a></li>
 
             {% comment %}

--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -94,7 +94,7 @@
 
       <div class="wrapper">
         <ul>
-          <li><a href="/">Home</a></li>
+          <li><a href="{{site.baseurl}}/">Home</a></li>
 
           <!-- {% for collection in site.collections %}
             {% if collection.label == page.collection %}

--- a/_layouts/collections/index.liquid
+++ b/_layouts/collections/index.liquid
@@ -41,7 +41,7 @@ layout: section
             {% endcomment %}
             {% for doc in collection_docs_ordered %}
               {% unless doc.layout == "collections/index" %}
-                <li><a href="{{ page.url }}#{{ doc.title | slugify }}">{{ doc.title }}</a></li>
+                <li><a href="{{ site.baseurl }}{{ page.url }}#{{ doc.title | slugify }}">{{ doc.title }}</a></li>
               {% endunless %}
             {% endfor %}
           </ul>

--- a/_layouts/homepage-draft.liquid
+++ b/_layouts/homepage-draft.liquid
@@ -7,11 +7,11 @@ layout: default
   <h2 class="subtitle--homepage">Get started</h2>
 
   <p class="longdesc">
-    Read <a href="/how-to-use-guide/">how to use this guide</a>. We also have a <a href="http://guides.service.gov.au/design-guide/">Design Guide</a> for building services.
+    Read <a href="{{ site.baseurl }}/how-to-use-guide/">how to use this guide</a>. We also have a <a href="http://guides.service.gov.au/design-guide/">Design Guide</a> for building services.
   </p>
   <p class="longdesc">
-   Learn how to <a href="/content-structure/">structure content</a>, write in <a href="/writing-style/">plain English</a> and create
-    <a href="/accessibility-inclusivity/"> accessible content</a> that includes everyone.
+   Learn how to <a href="{{ site.baseurl }}/content-structure/">structure content</a>, write in <a href="{{ site.baseurl }}/writing-style/">plain English</a> and create
+    <a href="{{ site.baseurl }}/accessibility-inclusivity/"> accessible content</a> that includes everyone.
   <p>
 
   <h2>Guidance</h2>
@@ -21,7 +21,7 @@ layout: default
     <ul class="collection-listing">
       {% comment %}<li>
         <h3>
-          <a href="/how-to-use-guide/">
+          <a href="{{ site.baseurl }}/how-to-use-guide/">
           How to use this guide
           </a>
         </h3>
@@ -31,7 +31,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/content-structure/">
+          <a href="{{ site.baseurl }}/content-structure/">
           Content structure
           </a>
         </h3>
@@ -41,7 +41,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/writing-style/">
+          <a href="{{ site.baseurl }}/writing-style/">
           Writing style
           </a>
         </h3>
@@ -51,7 +51,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/accessibility-inclusivity/">
+          <a href="{{ site.baseurl }}/accessibility-inclusivity/">
           Accessibility and inclusivity
           </a>
         </h3>
@@ -62,7 +62,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/punctuation-grammar/">
+          <a href="{{ site.baseurl }}/punctuation-grammar/">
           Punctuation and grammar
           </a>
         </h3>
@@ -72,7 +72,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/terms-phrases/">
+          <a href="{{ site.baseurl }}/terms-phrases/">
           Terms and phrases
           </a>
         </h3>
@@ -82,7 +82,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/numbers-measurements/">
+          <a href="{{ site.baseurl }}/numbers-measurements/">
           Numbers and measurements
           </a>
         </h3>
@@ -91,7 +91,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/formatting/">
+          <a href="{{ site.baseurl }}/formatting/">
           Formatting
           </a>
         </h3>
@@ -100,7 +100,7 @@ layout: default
 
       <li>
         <h3>
-          <a href="/types-of-content/">
+          <a href="{{ site.baseurl }}/types-of-content/">
           Types of content
           </a>
         </h3>

--- a/_pages/how-to-use.md
+++ b/_pages/how-to-use.md
@@ -16,17 +16,17 @@ The GOV.AU Content Guide and the [DTA Design Guide](http://guides.service.gov.au
 
 If you're new to content design we suggest you read this first:
 
-- [content structure](/content-structure/)
-- [plain English and writing style](/writing-style/)
-- [making accessible and inclusive content](/accessibility-inclusivity/)
+- [content structure]({{ site.baseurl }}/content-structure/)
+- [plain English and writing style]({{ site.baseurl }}/writing-style/)
+- [making accessible and inclusive content]({{ site.baseurl }}/accessibility-inclusivity/)
 
 If you're an experienced content creator, check guidance on:
 
-- [spelling government terms and phrases](/terms-phrases)
-- [how we punctuate](/punctuation-grammar)
-- [writing numbers and measurements](/numbers-measurements)
+- [spelling government terms and phrases]({{ site.baseurl }}/terms-phrases)
+- [how we punctuate]({{ site.baseurl }}/punctuation-grammar)
+- [writing numbers and measurements]({{ site.baseurl }}/numbers-measurements)
 
-We're working on [guidance on content types](/types-of-content), including documents, forms and surveys.
+We're working on [guidance on content types]({{ site.baseurl }}/types-of-content), including documents, forms and surveys.
 
 You'll find guidance on how we use the UI-Kit CSS framework to build common design patterns in the [DTA Design Guide](http://guides.service.gov.au/design-guide/).
 
@@ -36,7 +36,7 @@ The Content Guide is a living product built by the Digital Transformation Agency
 
 It  will continue to grow based on feedback, research and work on other DTA products.
 
-The [original sources for the Content Guide](/sources/) included the GOV.UK style guide, 18F Content Guide, The Guardian and Observer style guide and Style Manual: For Authors, Editors and Printers.
+The [original sources for the Content Guide]({{ site.baseurl }}/sources/) included the GOV.UK style guide, 18F Content Guide, The Guardian and Observer style guide and Style Manual: For Authors, Editors and Printers.
 
 ## Use the guide in your organisation
 

--- a/_punctuation-grammar/capitalisation.md
+++ b/_punctuation-grammar/capitalisation.md
@@ -79,7 +79,7 @@ Title contractions do not require punctuation.
 
 ### Publications
 
-Use [title case for legislation, acts and other publications](/terms-phrases/#australian-government).
+Use [title case for legislation, acts and other publications]({{ site.baseurl }}/terms-phrases/#australian-government).
 
 ### Department titles
 

--- a/_punctuation-grammar/colons.md
+++ b/_punctuation-grammar/colons.md
@@ -4,7 +4,7 @@ order: 10
 exclude_from_search: true
 ---
 
-Use a colon to lead into a [bullet point list](/content-structure/#bullet-point-lists) after a sentence fragment.
+Use a colon to lead into a [bullet point list]({{ site.baseurl }}/content-structure/#bullet-point-lists) after a sentence fragment.
 
 You can use a colon in a sentence fragment --- but bullet point lists are easier to read.
 

--- a/_punctuation-grammar/commas.md
+++ b/_punctuation-grammar/commas.md
@@ -6,7 +6,7 @@ exclude_from_search: true
 
 Use commas minimally.
 
-Commas increase clarity because they bring in a natural pause. But too many commas are a sign a sentence should be shorter, or needs to be changed into a [bullet point list](/content-structure/#bullet-point-lists).
+Commas increase clarity because they bring in a natural pause. But too many commas are a sign a sentence should be shorter, or needs to be changed into a [bullet point list]({{ site.baseurl }}/content-structure/#bullet-point-lists).
 
 {% include guide_example.liquid
   title = "using commas"

--- a/_punctuation-grammar/contractions.md
+++ b/_punctuation-grammar/contractions.md
@@ -16,7 +16,7 @@ Use contractions to create a more conversational voice. But make sure the user c
 "
 %}
 
-Low-literacy users and people who speak [languages other than English](/accessibility-inclusivity/#languages-other-than-english) may find contractions difficult to understand.
+Low-literacy users and people who speak [languages other than English]({{ site.baseurl }}/accessibility-inclusivity/#languages-other-than-english) may find contractions difficult to understand.
 
 Avoid less common colloquial contractions like &#8217;you'd&#8217;.
 
@@ -24,4 +24,4 @@ Always consider the context.
 
 Don't use contractions where a user may misunderstand what they are being asked to do, for example on a form.
 
-Follow [guidance on readability](/writing-style/#readability).
+Follow [guidance on readability]({{ site.baseurl }}/writing-style/#readability).

--- a/_punctuation-grammar/eg-ie-etc-nb.md
+++ b/_punctuation-grammar/eg-ie-etc-nb.md
@@ -6,7 +6,7 @@ exclude_from_search: true
 
 Avoid the Latin abbreviations eg, ie, etc (et cetera) and nb.
 
-[Don't use italics for Latin](/formatting/#italics).
+[Don't use italics for Latin]({{ site.baseurl }}/formatting/#italics).
 
 Use 'for example' instead of &#8217;eg&#8217;.
 

--- a/_punctuation-grammar/exclamation-marks.md
+++ b/_punctuation-grammar/exclamation-marks.md
@@ -4,4 +4,4 @@ order: 8
 exclude_from_search: true
 ---
 
-Don’t use exclamation marks. The modern [government tone](/writing-style/#tone) is calm and understated.
+Don’t use exclamation marks. The modern [government tone]({{ site.baseurl }}/writing-style/#tone) is calm and understated.

--- a/_punctuation-grammar/hyphens.md
+++ b/_punctuation-grammar/hyphens.md
@@ -34,7 +34,7 @@ Some nouns are also hyphenated. Check the [Macquarie Dictionary](https://www.mac
 
 Don’t hyphenate login or sign in.
 
-Also read guidance on [using sign in instead of log in](/terms-phrases/#digital-terms).
+Also read guidance on [using sign in instead of log in]({{ site.baseurl }}/terms-phrases/#digital-terms).
 
 {% include guide_example.liquid
   title = "punctuating sign in and log in"

--- a/_punctuation-grammar/semicolons.md
+++ b/_punctuation-grammar/semicolons.md
@@ -4,7 +4,7 @@ order: 11
 exclude_from_search: true
 ---
 
-Avoid using semicolons. Use shorter sentences, [em dashes](#em-dashes-mdash) or [bullet point lists](/content-structure/#bullet-point-lists) instead.
+Avoid using semicolons. Use shorter sentences, [em dashes](#em-dashes-mdash) or [bullet point lists]({{ site.baseurl }}/content-structure/#bullet-point-lists) instead.
 
 {% include guide_example.liquid
   title = "alternatives to semicolons"

--- a/_terms-phrases/abbreviations.md
+++ b/_terms-phrases/abbreviations.md
@@ -6,7 +6,7 @@ exclude_from_search: true
 
 Only use abbreviations of general terms if the abbreviation is the clearer and more common form.
 
-See also guidance on [abbreviating numbers and measures](/numbers-measurements/).
+See also guidance on [abbreviating numbers and measures]({{ site.baseurl }}/numbers-measurements/).
 
 {% include guide_example.liquid
   title = "abbreviations"

--- a/_terms-phrases/accessibility.md
+++ b/_terms-phrases/accessibility.md
@@ -4,4 +4,4 @@ order: 2
 exclude_from_search: true
 ---
 
-Use [preferred accessibility terms](/accessibility-inclusivity/#inclusive-language-and-terms).
+Use [preferred accessibility terms]({{ site.baseurl }}/accessibility-inclusivity/#inclusive-language-and-terms).

--- a/_terms-phrases/australian-government.md
+++ b/_terms-phrases/australian-government.md
@@ -10,7 +10,7 @@ Only use the ‘Commonwealth of Australia’ when talking about the legal entity
 
 Only capitalise 'government', 'group', 'parliament', 'state' and 'territory' in a formal title.
 
-Also see guidance on [capitalising legislation and government publications](/punctuation-grammar/#capitalisation).
+Also see guidance on [capitalising legislation and government publications]({{ site.baseurl }}/punctuation-grammar/#capitalisation).
 
 {% include guide_example.liquid
   title = "referring to the Australian Government"

--- a/_terms-phrases/gender.md
+++ b/_terms-phrases/gender.md
@@ -4,4 +4,4 @@ order: 8
 exclude_from_search: true
 ---
 
-Use [gender-neutral terms and avoid gendered pronouns](/accessibility-inclusivity/#inclusive-language-and-terms).
+Use [gender-neutral terms and avoid gendered pronouns]({{ site.baseurl }}/accessibility-inclusivity/#inclusive-language-and-terms).

--- a/_terms-phrases/indigenous.md
+++ b/_terms-phrases/indigenous.md
@@ -4,4 +4,4 @@ order: 9
 exclude_from_search: true
 ---
 
-Use [preferred First Australian terms](/accessibility-inclusivity/#aboriginal-and-torres-strait-islander-peoples) instead of Indigenous.
+Use [preferred First Australian terms]({{ site.baseurl }}/accessibility-inclusivity/#aboriginal-and-torres-strait-islander-peoples) instead of Indigenous.

--- a/_terms-phrases/plain-english-terms.md
+++ b/_terms-phrases/plain-english-terms.md
@@ -4,4 +4,4 @@ order: 11
 exclude_from_search: true
 ---
 
-See [plain English guidance](/writing-style/#plain-english).
+See [plain English guidance]({{ site.baseurl }}/writing-style/#plain-english).

--- a/_types-of-content/documents.md
+++ b/_types-of-content/documents.md
@@ -8,7 +8,7 @@ exclude_from_search: true
 
 Microsoft Word formats (`.doc` and `.docx`) don't conform to WCAG 2.0 when viewed on mobile devices.
 
-Don't publish Word documents on the web on their own. Provide the information on a HTML page as well. If this isn't possible, [create an accessible PDF](/accessibility-inclusivity/#pdf-accessibility).
+Don't publish Word documents on the web on their own. Provide the information on a HTML page as well. If this isn't possible, [create an accessible PDF]({{ site.baseurl }}/accessibility-inclusivity/#pdf-accessibility).
 
 Make Word documents accessible to everyone even if you are emailing them internally. This includes people who rely on assistive technologies, such as screen readers.
 

--- a/_types-of-content/fact-sheets.md
+++ b/_types-of-content/fact-sheets.md
@@ -6,4 +6,4 @@ exclude_from_search: true
 
 Publish fact sheets in HTML. This improves accessibility and allows for printing.
 
-If there is a user need to access the information as a PDF as well as HTML, you must [make the PDF accessible](/accessibility-inclusivity/#pdf-accessibility).
+If there is a user need to access the information as a PDF as well as HTML, you must [make the PDF accessible]({{ site.baseurl }}/accessibility-inclusivity/#pdf-accessibility).

--- a/_types-of-content/images.md
+++ b/_types-of-content/images.md
@@ -6,7 +6,7 @@ exclude_from_search: true
 
 Use images minimally and with purpose.
 
-[Make the images accessible](/accessibility-inclusivity/#images-and-alt-text).
+[Make the images accessible]({{ site.baseurl }}/accessibility-inclusivity/#images-and-alt-text).
 
 If you use images to enhance written information use real people and locations.
 

--- a/_types-of-content/pdfs.md
+++ b/_types-of-content/pdfs.md
@@ -7,6 +7,6 @@ exclude_from_search: true
 Only make a PDF if there is a strong user need.
 
 Follow guidance to
-[make accessible PDFs](/accessibility-inclusivity/#pdf-accessibility).
+[make accessible PDFs]({{ site.baseurl }}/accessibility-inclusivity/#pdf-accessibility).
 
 PDFs are not accessible on mobile devices.

--- a/_types-of-content/video.md
+++ b/_types-of-content/video.md
@@ -11,7 +11,7 @@ Video should be a complementary channel. It should enhance written information.
 ### Make the video accessible
 
 Read
-[guidance on transcripts, closed captions and audio description](/accessibility-inclusivity/#video-accessibility).
+[guidance on transcripts, closed captions and audio description]({{ site.baseurl }}/accessibility-inclusivity/#video-accessibility).
 
 ### Write a focused script
 
@@ -19,7 +19,7 @@ Think about what the user needs to know and make this your main focus.
 
 Get to the point early on.
 
-Check the [voice and tone](/writing-style/). Use humour sensitively.
+Check the [voice and tone]({{ site.baseurl }}/writing-style/). Use humour sensitively.
 
 ### Think visually
 

--- a/_writing-style/plain-english.md
+++ b/_writing-style/plain-english.md
@@ -12,7 +12,7 @@ Writing in plain English means using simpler and more direct language.
 
 It does not mean ‘dumbing down’ information. Plain English helps people make decisions and builds trust.
 
-Plain English [improves readability](/writing-style/#readability) for all users.
+Plain English [improves readability]({{ site.baseurl }}/writing-style/#readability) for all users.
 
 ### How to write in plain English
 
@@ -28,7 +28,7 @@ If you’re writing for a specialist audience, you still need to make sure every
 
 Write in plain English so everyone can understand, regardless of their ability.
 
-Think about the [needs of users who speak a language other than English](/accessibility-inclusivity/#languages-other-than-english).
+Think about the [needs of users who speak a language other than English]({{ site.baseurl }}/accessibility-inclusivity/#languages-other-than-english).
 
 ### Plain English words and terms
 

--- a/_writing-style/readability.md
+++ b/_writing-style/readability.md
@@ -41,4 +41,4 @@ When a user reaches a word or phrase that is unfamiliar or difficult it slows do
 
 A person's vocabulary will grow as they age but the shape-recognition skill stays with them.
 
-Writing for the Year 5 reading level, [structuring your writing](/content-structure/) and [writing in plain English](#plain-english) will make it easier for all users to read your content.
+Writing for the Year 5 reading level, [structuring your writing]({{ site.baseurl }}/content-structure/) and [writing in plain English](#plain-english) will make it easier for all users to read your content.

--- a/_writing-style/voice.md
+++ b/_writing-style/voice.md
@@ -38,4 +38,4 @@ The part-time role was approved in March.
 "
 %}
 
-Use [contractions](/punctuation-grammar/#contractions) carefully to be more conversational.
+Use [contractions]({{ site.baseurl }}/punctuation-grammar/#contractions) carefully to be more conversational.

--- a/bin/cibuild.sh
+++ b/bin/cibuild.sh
@@ -11,9 +11,23 @@ set -o pipefail
 set -x
 
 main() {
+  readonly GITBRANCH="${CIRCLE_BRANCH}"
+
   git submodule init                                                    # Pulling submodule
   git submodule update                                                  # Updating submodule
-  bundle exec jekyll build
+
+  case "${GITBRANCH}" in
+    master)
+      echo "Building with production jekyll config"
+
+      bundle exec jekyll build --destination ./_site/$CF_PATH --baseurl /$CF_PATH
+      # Building jekyll plus the path variable
+      ;;
+    *)
+      echo "Building with develop jekyll config"
+      bundle exec jekyll build
+      ;;
+  esac
 }
 
 main $@

--- a/bin/citest.sh
+++ b/bin/citest.sh
@@ -16,8 +16,19 @@ set -x
 # Run jekyll hyde
 bundle exec jekyll hyde
 
+# we want the link checker to fail if internal links have not correctly
+# appended site.baseurl, so we re-build the site with a non-empty baseurl
+
+# use /tmp if TMPDIR is not defined
+if [[ -z "$TMPDIR" ]]
+then
+    export TMPDIR="/tmp"
+fi
+
+bundle exec jekyll build --destination ${TMPDIR}/_site_link_checker/baseurl --baseurl /baseurl
+
 # Run a html proofer over the site to check all internal links
-bundle exec htmlproofer _site  \
+bundle exec htmlproofer ${TMPDIR}/_site_link_checker  \
     --disable-external \
     --allow-hash-href \
     --url-ignore "/(mailto:.*)/" \

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Major changes:
 
 - New information architecture, content refactoring and search functionality.
 - Expanded guidance on [accessibility and inclusivity]({{ site.baseurl }}/accessibility-inclusivity).
-- Built with [UI-Kit CSS framework version 1]({{ site.baseurl }}http://guides.service.gov.au/design-guide/).
+- Built with [UI-Kit CSS framework version 1](http://guides.service.gov.au/design-guide/).
 
 <p>
 <svg class="icon-inline fa-github" role="img" title="GitHub icon" aria-labelledby="fa-github-alt-source">

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ abstract: ""
 
 ## Sources
 
-List of the [resources used to write the GOV.AU Content Guide](/sources/).
+List of the [resources used to write the GOV.AU Content Guide]({{ site.baseurl }}/sources/).
 
 ## Latest updates
 
@@ -17,8 +17,8 @@ Live release of the GOV.AU Content Guide.
 Major changes:
 
 - New information architecture, content refactoring and search functionality.
-- Expanded guidance on [accessibility and inclusivity](/accessibility-inclusivity).
-- Built with [UI-Kit CSS framework version 1](http://guides.service.gov.au/design-guide/).
+- Expanded guidance on [accessibility and inclusivity]({{ site.baseurl }}/accessibility-inclusivity).
+- Built with [UI-Kit CSS framework version 1]({{ site.baseurl }}http://guides.service.gov.au/design-guide/).
 
 <p>
 <svg class="icon-inline fa-github" role="img" title="GitHub icon" aria-labelledby="fa-github-alt-source">

--- a/updates.md
+++ b/updates.md
@@ -7,7 +7,7 @@ Live release of the DTA Content Guide
 Major changes:
 
 - new IA and content refactoring
-- expanded guidance on [accessibility and inclusivity](/accessibility-inclusivity)
+- expanded guidance on [accessibility and inclusivity]({{ site.baseurl }}/accessibility-inclusivity)
 - build with [UI-Kit](https://github.com/AusDTO/gov-au-ui-kit){:rel="external"}.
 
 <p>


### PR DESCRIPTION
When the content-guide is deployed in production, it needs a `site.baseurl`. The link checker is not flagging links which are missing a site.baseurl until it is run on the `master` branch. 

I've quickly fixed in this PR so the link checker will now always flag links which are missing site.baseurl. What I've done is a bit of a hack, but it will let us find and fix links in the content more easily for now. I'll try to come back and refactor it later.

This is a work in progress - I've started fixing the broken links, reducing it from 396 broken links down to 80ish. Maybe @joolswood can take over and fix the rest?