### PR TITLE
Fix image urls

### DIFF
--- a/_assets/scss/guide.scss
+++ b/_assets/scss/guide.scss
@@ -287,7 +287,7 @@ $site-search-outline--focus:                  $light-aqua;
 } //.site-search
 
 .site-search .submit {
-    background-image: url(/assets/search--navy.svg);
+    background-image: url(asset_path("search--navy.svg"));
 }
 
 .no-js .site-search label {

--- a/index.md
+++ b/index.md
@@ -23,6 +23,6 @@ Major changes:
 <p>
 <svg class="icon-inline fa-github" role="img" title="GitHub icon" aria-labelledby="fa-github-alt-source">
 <title id="fa-github-alt-source" lang="en">GitHub icon</title>
-<use xlink:href="/assets/spritesheet.svg#fa-github"/>
+<use xlink:href="{% asset_path spritesheet.svg %}#fa-github"/>
 </svg> Read the <a href="https://github.com/govau/content-guide/blob/master/CHANGELOG.md" rel="external">full Content Guide changelog on GitHub</a>.
 </p>


### PR DESCRIPTION
Fixing a couple of images that weren't including site.baseurl in their urls. 

I've changed them to use the asset_path helper from [jekyll-assets](https://github.com/jekyll/jekyll-assets) which ensures this url includes site.baseurl, and will also make the images work when the site is compiled with JEKYLL_ENV set to production later.