### PR TITLE
Small improvements to guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Updates to the GOV.AU Content Guide
 
-### 1.1.0 &#8212; X June 2017
+### 1.1.0 &#8212; 6 June 2017
 
+#### Guidance improvements
 
+- Improved example for date ranges.
+- Added reminder to use skip links.
+- Added guidance on writing headings.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Updates to the GOV.AU Content Guide
 
+### 1.1.0 &#8212; X June 2017
+
+
+
+#### Fixed
+
+- Typo in Dates example.
+- Correct link in Italics.
+
+### 1.0.2 &#8212; 25 May 2017
+
+#### Fixed
+
+- Typo in Legislation, acts and other publications.
+- Typo in Aboriginal and Torres Strait Islander peoples example.
+
 ### 1.0.1 &#8212; 5 May 2017
 
-### Fixed
+#### Fixed
 
 - Fix missing icon on the search bar bug.
 - Fix missing GitHub icon on homepage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Updates to the GOV.AU Content Guide
 
-### 1.1.0 &#8212; 6 June 2017
+### 1.1.0 &#8212; 7 June 2017
 
 #### Guidance improvements
 

--- a/_accessibility-inclusivity/links.md
+++ b/_accessibility-inclusivity/links.md
@@ -6,4 +6,6 @@ exclude_from_search: true
 
 Create [precise links and place them carefully]({{ site.baseurl }}/content-structure/#hyperlinks) where users need them.
 
+Add [skip links](https://guides.service.gov.au/design-guide/patterns/navigation/#skip-links) to navigation and content.
+
 Make it easy for all users to know where they need to go.

--- a/_content-structure/headings-subheadings.md
+++ b/_content-structure/headings-subheadings.md
@@ -4,7 +4,7 @@ order: 4
 exclude_from_search: true
 ---
 
-The user should be able to get an understanding of the whole page content by scanning the headings.
+The user should be able to get an understanding of the content by scanning the headings.
 
 ### Make the title short and accurate
 

--- a/_content-structure/headings-subheadings.md
+++ b/_content-structure/headings-subheadings.md
@@ -4,6 +4,8 @@ order: 4
 exclude_from_search: true
 ---
 
+The user should be able to get an understanding of the whole page content by scanning the headings.
+
 ### Make the title short and accurate
 
 Write a clear title and lead summary. Tell the user what the page is about and who it's for.

--- a/_formatting/italics.md
+++ b/_formatting/italics.md
@@ -12,7 +12,7 @@ Users with dyslexia can find italics very difficult to read.
 
 Don't use italics in headlines.
 
-Use [capitals instead of italics for acts and other publications]({{ site.baseurl }}/punctuation-grammar/#capitalisation). Link to the source where possible.
+Use [title case not italics for acts and other publications]({{ site.baseurl }}/terms-phrases/#legislation-acts-and-other-publications). Link to the source where possible.
 
 ### Avoid Latin words
 

--- a/_numbers-measurements/dates.md
+++ b/_numbers-measurements/dates.md
@@ -43,6 +43,6 @@ We are open Monday to Friday, 9am to 5pm.
 
 This will take 10 to 15 minutes.
 
-We published the 2015 to 2016 Annual Report.
+We published the annual report for the 2015 to 2016 financial year.
 "
 %}

--- a/_numbers-measurements/dates.md
+++ b/_numbers-measurements/dates.md
@@ -43,7 +43,7 @@ We are open Monday to Friday, 9am to 5pm.
 
 This will take 10 to 15 minutes.
 
-This is covers these financial years:
+This covers these financial years:
 - 2013 to 2014
 - 2014 to 2015
 - 2015 to 2016

--- a/_numbers-measurements/dates.md
+++ b/_numbers-measurements/dates.md
@@ -43,9 +43,6 @@ We are open Monday to Friday, 9am to 5pm.
 
 This will take 10 to 15 minutes.
 
-This covers these financial years:
-- 2013 to 2014
-- 2014 to 2015
-- 2015 to 2016
+We published the 2015 to 2016 Annual Report.
 "
 %}

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ List of the [resources used to write the GOV.AU Content Guide]({{ site.baseurl }
 
 ## Latest updates
 
-### 6 June 2017
+### 7 June 2017
 
 - Improved example for [date ranges]({{ site.baseurl }}/numbers-measurements/#dates).
 - Added reminder to [use skip links]({{ site.baseurl }}/accessibility-inclusivity/#hyperlinks).

--- a/index.md
+++ b/index.md
@@ -10,15 +10,11 @@ List of the [resources used to write the GOV.AU Content Guide]({{ site.baseurl }
 
 ## Latest updates
 
-### 3 May 2017
+### 6 June 2017
 
-Live release of the GOV.AU Content Guide.
-
-Major changes:
-
-- New information architecture, content refactoring and search functionality.
-- Expanded guidance on [accessibility and inclusivity]({{ site.baseurl }}/accessibility-inclusivity).
-- Built with [UI-Kit CSS framework version 1](http://guides.service.gov.au/design-guide/).
+- Improved example for [date ranges]({{ site.baseurl }}/numbers-measurements/#dates).
+- Added reminder to [use skip links]({{ site.baseurl }}/accessibility-inclusivity/#hyperlinks).
+- Added guidance on [writing headings]({{ site.baseurl }}/content-structure/#headings-and-subheadings).
 
 <p>
 <svg class="icon-inline fa-github" role="img" title="GitHub icon" aria-labelledby="fa-github-alt-source">


### PR DESCRIPTION
- Using title case for publications, not italics
- Skip links
- Date ranges
- Update home page changes list