### PR TITLE
Change to use jekyll-assets helper

### DIFF
--- a/_accessibility-inclusivity/images-alt-text.md
+++ b/_accessibility-inclusivity/images-alt-text.md
@@ -36,7 +36,7 @@ In HTML5 [use the `<figcaption>` tag](https://www.w3.org/wiki/HTML/Elements/figc
 
 {% capture content %}
 <figure>
-  <img src='{{site.baseurl}}/assets/coat-of-arms.png' alt='' />
+  <img src='{% asset_path "coat-of-arms.png" %}' alt='' />
   <figcaption>Caption: the conventional version of the Commonwealth Coat of Arms of Australia.</figcaption>
 </figure>
 {% endcapture %}

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -64,14 +64,14 @@
             <li>
             <svg class="icon-inline fa-github" role="img" title="GitHub icon" aria-labelledby="fa-github-alt-source">
               <title id="fa-github-alt-source" lang="en">GitHub icon</title>
-              <use xlink:href="{{ site.baseurl }}/assets/spritesheet.svg#fa-github"/>
+              <use xlink:href="{% asset_path "spritesheet.svg" %}#fa-github"/>
             </svg>
             <a href="{{ site.github_url }}/issues/new" rel="external">Report an issue on GitHub</a></li>
             {% endif %}
 
             <li>
               <svg class="icon-inline fa-envelope-o" role="img" title="envelope email icon">
-                <use xlink:href="{{ site.baseurl }}/assets/spritesheet.svg#fa-envelope-o"/>
+                <use xlink:href="{% asset_path "spritesheet.svg" %}#fa-envelope-o"/>
               </svg>
               <a href="mailto:{{ site.email_team }}">{{ site.email_team }}</a>
             </li>
@@ -103,7 +103,7 @@
         <p>
           <svg class="icon-inline fa-github" role="img" title="GitHub icon" aria-labelledby="fa-github-alt-source">
             <title id="fa-github-alt-source" lang="en">GitHub icon</title>
-            <use xlink:href="{{ site.baseurl }}/assets/spritesheet.svg#fa-github"/>
+            <use xlink:href="{% asset_path "spritesheet.svg" %}#fa-github"/>
           </svg>
 
           <a class="footer-link" href="{{ site.github_url }}" rel="external">

--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -17,7 +17,7 @@
           <a href="{{ site.baseurl }}/" class="logo">
             <svg role="img" title="Content Guide logo" aria-labelledby="dc_logo-title">
               <title id="dc_logo-title" lang="en">Content Guide logo</title>
-              <use xlink:href="{{ site.baseurl }}/assets/spritesheet.svg#dc_logo"/>
+              <use xlink:href="{% asset_path "spritesheet.svg" %}#dc_logo"/>
             </svg>
             <span>{{ site.title }}</span>
           </a>
@@ -50,7 +50,7 @@
           <a href="{{ site.baseurl }}/" class="logo">
             <svg role="img" title="Content Guide logo" aria-labelledby="dc_logo-title">
               <title id="dc_logo-title" lang="en">Content Guide logo</title>
-              <use xlink:href="{{ site.baseurl }}/assets/spritesheet.svg#dc_logo"/>
+              <use xlink:href="{% asset_path "spritesheet.svg" %}#dc_logo"/>
             </svg>
 
             <h1>{{ site.title }}</h1>


### PR DESCRIPTION
When the site is built with JEKYLL_ENV=production, jekyll-assets will mangle the paths to the assets with a hash, and any references to the assets needs to know about the path. Hence we now need to use the jekyll-assets provided helpers. e.g. https://github.com/envygeeks/jekyll-assets/tree/v2.2.8#tags
